### PR TITLE
Refactor: enhance generator readability

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = {
     let password = ''
     while (password.length < length) {
       const charIndex = crypto.randomInt(0, allowsChars.length)
-      if (password.length === 0 && generateOptions.digits === true && allowsChars[charIndex] === '0') {
+      if (password.length === 0 && allowsChars[charIndex] === '0') {
         continue
       }
       password += allowsChars[charIndex]

--- a/index.js
+++ b/index.js
@@ -22,10 +22,10 @@ module.exports = {
     length = length || 10
     const generateOptions = options || {}
 
-    generateOptions.digits = Object.prototype.hasOwnProperty.call(generateOptions, 'digits') ? options.digits : true
-    generateOptions.lowerCaseAlphabets = Object.prototype.hasOwnProperty.call(generateOptions, 'lowerCaseAlphabets') ? options.lowerCaseAlphabets : true
-    generateOptions.upperCaseAlphabets = Object.prototype.hasOwnProperty.call(generateOptions, 'upperCaseAlphabets') ? options.upperCaseAlphabets : true
-    generateOptions.specialChars = Object.prototype.hasOwnProperty.call(generateOptions, 'specialChars') ? options.specialChars : true
+    generateOptions.digits ??= true
+    generateOptions.lowerCaseAlphabets ??= true
+    generateOptions.upperCaseAlphabets ??= true
+    generateOptions.specialChars ??= true
 
     const allowsChars = ((generateOptions.digits || '') && digits) +
       ((generateOptions.lowerCaseAlphabets || '') && lowerCaseAlphabets) +


### PR DESCRIPTION
- Simplify the [checking of properties](https://github.com/Maheshkumar-Kakade/otp-generator/blob/master/index.js#L25C1-L28C135) in `generateOptions`.
- Remove extra check:
  I guess checking if `generateOptions.digits === true` [here](https://github.com/Maheshkumar-Kakade/otp-generator/blob/d9a5774e446242bc27f0ba88d1428fb7db685176/index.js#L37)  is unecessary (it will always be true if the selected character is '0').